### PR TITLE
Choice Messages, RL Eval Pretrained Cleanups

### DIFF
--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
     from argparse import ArgumentParser
 
     parser = ArgumentParser()
-    parser.add_argument("--gen", type=int, choices=list(range(1, 10)), required=True)
+    parser.add_argument("--gen", type=int, choices=list(range(1, 5)), required=True)
     parser.add_argument(
         "--raw_replay_dir", required=True, help="Path to raw replay dataset folder."
     )

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -175,7 +175,17 @@ class POVReplay:
             )  # turn_t holds the state at the very end of the turn
             # and the action we clicked between turns is held in the next turn
             moves = turn_t1.moves_1 if self.from_p1_pov else turn_t1.moves_2
-            self.actionlist.append(moves)
+            choices = turn_t1.choices_1 if self.from_p1_pov else turn_t1.choices_2
+            actionlist = [None, None]
+            for move_idx, (move, choice) in enumerate(zip(moves, choices)):
+                if move is not None:
+                    # we default to the original system of *used* moves
+                    actionlist[move_idx] = move
+                elif choice is not None:
+                    # if the move was missing, but a `choice` message was parsed,
+                    # we can fall back to that.
+                    actionlist[move_idx] = choice
+            self.actionlist.append(actionlist)
 
         # add final state
         self.povturnlist.append(turn_t1)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -24,9 +24,8 @@ from metamon.data.team_builder import PokemonStatsLookupError, TeamBuilder
 def get_team_builder(format: str) -> Optional[TeamBuilder]:
     team_builder = TeamBuilder(
         format,
-        ps_path="/home/jake/pokemon-showdown/",
         verbose=False,
-        remove_banned=False,
+        remove_banned=True,  # TODO: remove this
         inclusive=True,
     )
     if len(team_builder.stat.movesets) == 0:
@@ -63,6 +62,7 @@ def fill_missing_team_info(
         sample_team = team_builder.generate_new_team(pokemon_names)
     except PokemonStatsLookupError as e:
         raise BackwardException(str(e))
+    breakpoint()
     sample_team_dict = {x["name"]: x for x in sample_team}
 
     # Fill in missing pokemon

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -62,7 +62,6 @@ def fill_missing_team_info(
         sample_team = team_builder.generate_new_team(pokemon_names)
     except PokemonStatsLookupError as e:
         raise BackwardException(str(e))
-    breakpoint()
     sample_team_dict = {x["name"]: x for x in sample_team}
 
     # Fill in missing pokemon

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
@@ -1,8 +1,7 @@
 import copy
 from dataclasses import dataclass, field
 from datetime import datetime
-from itertools import chain
-from typing import List, Optional, Set
+from typing import List, Optional
 
 from metamon.data.replay_dataset.parsed_replays.replay_parser import checks
 from metamon.data.replay_dataset.parsed_replays.replay_parser.exceptions import *

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
@@ -2,7 +2,7 @@ import copy
 from dataclasses import dataclass, field
 from datetime import datetime
 from itertools import chain
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from metamon.data.replay_dataset.parsed_replays.replay_parser import checks
 from metamon.data.replay_dataset.parsed_replays.replay_parser.exceptions import *
@@ -97,7 +97,6 @@ class SpecialCategories:
         "Copycat",
         "Nature Power",
         "Magic Coat",
-        "magiccoat",
         "Mirror Move",
         "Assist",
         "Snatch",
@@ -254,9 +253,26 @@ def parse_row(replay: ParsedReplay, row: List[str]):
             )
 
     elif name == "choice":
-        # if only this worked in every replay. it might be possible to get more
-        # accurate in some situations when we know we can trust the choice messages.
-        pass
+        # https://github.com/smogon/pokemon-showdown/blob/master/sim/SIM-PROTOCOL.md#sending-decisions
+        # `choice` messaegs reveal players action choices directly instead of waiting to see the outcome of the move/switch.
+        # they are not present in every replay, but when they are, they can help us fill missing actions.
+        # It would be possible to catch many more choices if we could use the numeric arg format of some
+        # messages (e.g. `move 1`). We'd need to infer a mapping between the numeric args and the move names.
+        for player_idx, player_choice in enumerate(data):
+            if player_choice:
+                for poke_idx, poke_choice in enumerate(player_choice.split(",")):
+                    msg = poke_choice.split(" ")
+                    command = msg[0]
+                    args = re.sub(r'\d+', '', " ".join(msg[1:])).strip()
+                    if command == "move" and args and args.lower() not in {"recharge", "struggle"}:
+                        user_pokemon = curr_turn.active_pokemon_1[poke_idx] if player_idx == 0 else curr_turn.active_pokemon_2[poke_idx]
+                        move = Move(name=args, gen=replay.gen)
+                        choice = Action(name=move.name, is_switch=False, is_noop=False, user=user_pokemon, target=None)
+                        user_pokemon.reveal_move(move)
+                        if player_idx == 0:
+                            curr_turn.choices_1[poke_idx] = choice
+                        else:
+                            curr_turn.choices_2[poke_idx] = choice
 
     elif name == "tie":
         # |tie
@@ -371,8 +387,6 @@ def parse_row(replay: ParsedReplay, row: List[str]):
                         return
                 elif is_ability:
                     raise UnimplementedMoveFromMoveAbility(data)
-                    #ability = parse_ability_from_extra(extra_from_message)
-                    #pokemon.reveal_ability(ability)
             else:
                 # OLD REPLAY VERSION
                 ability_or_move = parse_extra(extra_from_message)
@@ -385,7 +399,7 @@ def parse_row(replay: ParsedReplay, row: List[str]):
                         if ability_or_move in SpecialCategories.MOVE_OVERRIDE_BUT_REVEAL_ANYWAY:
                             pokemon.reveal_move(move)
                         return
-                probably_ability = ability_or_move not in {"lockedmove", "pursuit", "Pursuit"} and not probably_item and not probably_repeat_move
+                probably_ability = ability_or_move.lower() not in {"lockedmove", "pursuit"} and not probably_item and not probably_repeat_move
                 if probably_ability:
                     raise UnimplementedMoveFromMoveAbility(data)
 
@@ -426,7 +440,7 @@ def parse_row(replay: ParsedReplay, row: List[str]):
         # create Action
         curr_turn.set_move_attribute(
             s=poke_str,
-            move_name=move_name,
+            move_name=move.name,
             is_noop=False,
             is_switch=False,
             user=pokemon,
@@ -868,9 +882,13 @@ def parse_row(replay: ParsedReplay, row: List[str]):
         effect = PEEffect.from_showdown_message(data[1])
         if effect == PEEffect.PROTECT:
             pokemon.protected = True
-
+    
     else:
-        raise UnimplementedMessage(row)
+        if data[0].startswith(">>>"):
+            # leaked browser console messages?
+            pass
+        else:
+            raise UnimplementedMessage(row)
 
 
 def forward_fill(replay: ParsedReplay, log: list[list[str]], verbose: bool = False) -> ParsedReplay:
@@ -880,6 +898,7 @@ def forward_fill(replay: ParsedReplay, log: list[list[str]], verbose: bool = Fal
                 print(row)
             parse_row(replay, row)
 
+    checks.check_noun_spelling(replay)
     checks.check_finished(replay)
     checks.check_replay_rules(replay)
     checks.check_forward_consistency(replay)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
@@ -158,7 +158,7 @@ class ReplayParser:
                     rewards=rewards,
                 )
 
-    def add_exception_to_history(self, e):
+    def add_exception_to_history(self, e, path):
         if isinstance(e, ForwardException):
             e_dict = self.error_history["Forward"]
         elif isinstance(e, BackwardException):
@@ -191,7 +191,7 @@ class ReplayParser:
         p1_username, p2_username = data["players"]
         time_played = datetime.fromtimestamp(int(data["uploadtime"]))
         replay = forward.ParsedReplay(
-            gameid="-".join(path.split("-")[-2:]).replace(".json", ""),
+            gameid=os.path.basename(path).replace(".json", ""),
             format=data["format"],
             time_played=time_played,
         )
@@ -222,5 +222,5 @@ class ReplayParser:
             )
 
         except (ForwardException, BackwardException) as e:
-            self.add_exception_to_history(e)
+            self.add_exception_to_history(e, path)
             warnings.warn(f"Skipping replay {path} due to known exception: {e}.")

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/str_parsing.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/str_parsing.py
@@ -52,7 +52,10 @@ def parse_extra(raw: str) -> str:
     *_, info = raw.split("[from]")
     if "[from]" not in raw or not info:
         raise StrParsingException("parse_extra", raw)
-    return info.strip()
+    info = info.strip()
+    if info.startswith("move:"):
+        info = info.replace("move:", "").strip()
+    return info
 
 
 def parse_effect(effect: str) -> str:

--- a/metamon/data/team_builder/format_rules.py
+++ b/metamon/data/team_builder/format_rules.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import re
 import json
 from enum import Enum
@@ -68,7 +69,27 @@ def ts_to_dict(ts_file):
     return data
 
 
-def get_valid_pokemon(ps_path, format):
+def find_global_npm_package_path(package_name):
+    # Get the global node_modules path
+    npm_root = subprocess.check_output(["npm", "root", "-g"], text=True).strip()
+    breakpoint()
+    package_path = os.path.join(npm_root, package_name)
+    if os.path.exists(package_path):
+        return package_path
+    else:
+        return None
+
+
+def get_valid_pokemon(format):
+    ps_path = os.path.join(
+        os.path.abspath(__file__).split("metamon")[0],
+        "metamon",
+        "server",
+        "pokemon-showdown",
+    )
+    if not os.path.exists(ps_path):
+        raise ImportError("Cannot find path to pokemon-showdown")
+
     if "gen9" in format:
         formats_data = "formats-data.ts"
 

--- a/metamon/data/team_builder/format_rules.py
+++ b/metamon/data/team_builder/format_rules.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import re
 import json
 from enum import Enum
@@ -67,17 +66,6 @@ def ts_to_dict(ts_file):
 
     data = json.loads(content)
     return data
-
-
-def find_global_npm_package_path(package_name):
-    # Get the global node_modules path
-    npm_root = subprocess.check_output(["npm", "root", "-g"], text=True).strip()
-    breakpoint()
-    package_path = os.path.join(npm_root, package_name)
-    if os.path.exists(package_path):
-        return package_path
-    else:
-        return None
 
 
 def get_valid_pokemon(format):

--- a/metamon/data/team_builder/stat_reader.py
+++ b/metamon/data/team_builder/stat_reader.py
@@ -5,18 +5,7 @@ from metamon.data import DATA_PATH
 from metamon.data.download_stats import download_data
 from metamon.data.team_builder.format_rules import get_valid_pokemon, Tier
 
-from functools import lru_cache
-
-# Src: https://github.com/hsahovic/poke-env/blob/master/src/poke_env/data/normalize.py
-@lru_cache(2**13)
-def to_id_str(name: str) -> str:
-    """Converts a full-name to its corresponding id string.
-    :param name: The name to convert.
-    :type name: str
-    :return: The corresponding id string.
-    :rtype: str
-    """
-    return "".join(char for char in name if char.isalnum()).lower()
+from poke_env.data import to_id_str
 
 TIER_MAP = {
     "ubers": Tier.UBERS,
@@ -91,8 +80,8 @@ class SmogonStat:
         for i, (check, usage) in enumerate(sorted_checks[:5]):
             print(f"\t\t{i+1}. {check} ({usage * 100: .1f}%)")
 
-    def remove_banned_pm(self, ps_path):
-        valid_pm_dict = get_valid_pokemon(ps_path, self.format[:4])
+    def remove_banned_pm(self):
+        valid_pm_dict = get_valid_pokemon(self.format)
         tier = TIER_MAP[self.format[4:]]
         valid_pm = []
         # get all pokemon valid in this tier

--- a/metamon/data/team_builder/team_builder.py
+++ b/metamon/data/team_builder/team_builder.py
@@ -15,13 +15,11 @@ class PokemonStatsLookupError(KeyError):
 
 
 class TeamBuilder:
-    def __init__(
-        self, format, ps_path, verbose=True, remove_banned=True, inclusive=False
-    ):
+    def __init__(self, format, verbose=True, remove_banned=True, inclusive=False):
         self.format = format
         self.stat = PreloadedSmogonStat(format, verbose=verbose, inclusive=inclusive)
         if remove_banned:
-            self.stat.remove_banned_pm(ps_path)
+            self.stat.remove_banned_pm()
         self.verbose = verbose
 
         # use for different hp ivs

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "termcolor",
         "huggingface_hub",
         "poke-env @ git+https://github.com/jakegrigsby/poke-env.git",
-        "amago @ git+https://github.com/ut-austin-rpl/amago.git",
+        "amago @ git+https://github.com/ut-austin-rpl/amago.git@main",
     ],
 )


### PR DESCRIPTION
Prototype use of `choice` messages to detect actions that were previously unrevealed in some replays. 

Other replay parser cleanups.

Cleanup `rl/eval_pretrained` to expose observation space, tokenizer, and reward function settings that can change in the future.


Next up: save partially complete poke paste files from teams revealed during replays.