### PR TITLE
Refactor Replay Parser to Output UniversalStates

### DIFF
--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/README.md
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/README.md
@@ -20,7 +20,7 @@ And infers missing information to produce training data like:
 
 More information and discussion in Appendix D of the paper.
 
-**If you would like to train on your own set of Showdown replay logs, and/or would like to change the observation or reward function of existing replays, you will need run the replay parser**. Please be warned that it is poorly documented and requires significant Pokémon knowledge to debug/improve/extend. It is not really expected that this part of the codebase will be used externally. However, you can open an issue and I will get back to you. Updates are expected:
+Please be warned that it is poorly documented and requires significant Pokémon knowledge to debug/improve/extend. It is not really expected that this part of the codebase will be used externally. However, you can open an issue and I will get back to you. Updates are expected:
 
 ### Roadmap
 - Improved team inference logic (beyond all-time averages of Showdown usage stats)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
@@ -82,8 +82,7 @@ if __name__ == "__main__":
         else None
     )
     team_predictor = eval(args.team_predictor)()
-    team_predictor.set_format(battle_format)
-
+    team_predictor.num_processes = args.processes
     parser = ReplayParser(
         replay_output_dir=output_dir,
         team_output_dir=team_output_dir,

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
@@ -32,6 +32,12 @@ if __name__ == "__main__":
         help="Start parsing from this index of the dataset (skip replays you've already checked)",
     )
     parser.add_argument(
+        "--end_after",
+        type=int,
+        default=None,
+        help="Stop parsing after this many replays",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Prints the raw replay stream during parsing (useful for debugging)",
@@ -69,6 +75,8 @@ if __name__ == "__main__":
         filenames = [f for f in filenames if args.filter_by_code in f]
     if args.start_from is not None:
         filenames = filenames[args.start_from :]
+    if args.end_after is not None:
+        filenames = filenames[: args.end_after]
     if args.max is not None:
         filenames = filenames[: args.max]
 
@@ -81,13 +89,11 @@ if __name__ == "__main__":
         if args.team_output_dir
         else None
     )
-    team_predictor = eval(args.team_predictor)()
-    team_predictor.num_processes = args.processes
     parser = ReplayParser(
         replay_output_dir=output_dir,
         team_output_dir=team_output_dir,
         verbose=args.verbose,
-        team_predictor=team_predictor,
+        team_predictor=eval(args.team_predictor)(),
     )
     if args.processes > 1:
         random.shuffle(filenames)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -33,6 +33,10 @@ def fill_missing_team_info(
         predicted_team = team_predictor.predict(copy.deepcopy(revealed_team))
     except Exception as e:
         raise BackwardException(f"Could not predict team for {revealed_team}")
+
+    if not revealed_team.is_consistent_with(predicted_team):
+        raise InconsistentTeamPrediction(revealed_team, predicted_team)
+
     pokemon_to_add = [
         poke for poke in predicted_team.pokemon if poke.name not in poke_names
     ]

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -29,10 +29,10 @@ def fill_missing_team_info(
     revealed_team = TeamSet(
         lead=converted_poke[0], reserve=converted_poke[1:], format=battle_format
     )
-    try:
-        predicted_team = team_predictor.predict(copy.deepcopy(revealed_team))
-    except Exception as e:
-        raise BackwardException(f"Could not predict team for {revealed_team}")
+    # try:
+    predicted_team = team_predictor.predict(copy.deepcopy(revealed_team))
+    # except Exception as e:
+    #    raise BackwardException(f"Could not predict team for {revealed_team}")
 
     if not revealed_team.is_consistent_with(predicted_team):
         raise InconsistentTeamPrediction(revealed_team, predicted_team)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -17,6 +17,7 @@ from metamon.data.replay_dataset.parsed_replays.replay_parser.replay_state impor
 )
 from metamon.data.team_prediction.predictor import TeamPredictor
 from metamon.data.team_prediction.team import TeamSet, PokemonSet
+from metamon.data.team_builder.team_builder import PokemonStatsLookupError
 
 
 def fill_missing_team_info(
@@ -28,7 +29,10 @@ def fill_missing_team_info(
     revealed_team = TeamSet(
         lead=converted_poke[0], reserve=converted_poke[1:], format=battle_format
     )
-    predicted_team = team_predictor.predict(copy.deepcopy(revealed_team))
+    try:
+        predicted_team = team_predictor.predict(copy.deepcopy(revealed_team))
+    except Exception as e:
+        raise BackwardException(f"Could not predict team for {revealed_team}")
     pokemon_to_add = [
         poke for poke in predicted_team.pokemon if poke.name not in poke_names
     ]

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -23,20 +23,28 @@ from metamon.data.team_builder.team_builder import PokemonStatsLookupError
 def fill_missing_team_info(
     battle_format: str, poke_list: List[Pokemon], team_predictor: TeamPredictor
 ) -> List[Pokemon]:
+    """
+    Team prediction works by:
+
+    1. Converting the team we've gathered here in the replay parser to the format expected by the team_prediction module
+    2. Predicting the team with a TeamPredictor
+    3. Filling missing information with the predicted team
+    """
+
+    # 1. Convert the team to the format expected by the team_prediction module
     gen = int(battle_format.split("gen")[1][0])
     poke_names = [p.name for p in poke_list if p is not None]
     converted_poke = [PokemonSet.from_ReplayPokemon(p, gen=gen) for p in poke_list]
     revealed_team = TeamSet(
         lead=converted_poke[0], reserve=converted_poke[1:], format=battle_format
     )
-    # try:
-    predicted_team = team_predictor.predict(copy.deepcopy(revealed_team))
-    # except Exception as e:
-    #    raise BackwardException(f"Could not predict team for {revealed_team}")
 
+    # 2. Predict the team
+    predicted_team = team_predictor.predict(revealed_team)
     if not revealed_team.is_consistent_with(predicted_team):
         raise InconsistentTeamPrediction(revealed_team, predicted_team)
 
+    # 3. Filling missing information with the predicted team
     pokemon_to_add = [
         poke for poke in predicted_team.pokemon if poke.name not in poke_names
     ]
@@ -44,10 +52,16 @@ def fill_missing_team_info(
         generated = pokemon_to_add.pop(0)
         new_pokemon = Pokemon(name=generated.name, lvl=100, gen=gen)
         poke_list[poke_list.index(None)] = new_pokemon
+
     if None in poke_list:
         raise BackwardException(
             f"Could not fill in all missing pokemon for {poke_list} with {predicted_team}"
         )
+
+    names = [p.name for p in poke_list]
+    if len(names) != len(set(names)):
+        raise BackwardException(f"Duplicate pokemon names in {names}")
+
     for p in poke_list:
         for match in predicted_team.pokemon:
             if match.name == p.name:
@@ -56,8 +70,6 @@ def fill_missing_team_info(
             raise BackwardException(f"Could not find match for {p.name}")
         p.fill_from_PokemonSet(match)
 
-    for name in poke_names:
-        assert name in [p.name for p in poke_list]
     return poke_list, revealed_team
 
 

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/checks.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/checks.py
@@ -176,27 +176,8 @@ def check_filled_mon(pokemon):
         raise BackwardException(f"Pokemon info has not been filled: {p}")
 
     moveset_size = len(pokemon.moves)
-    no_duplicates = len(pokemon.moves) == len(set(m.id for m in pokemon.moves.values()))
-    if not no_duplicates:
-        breakpoint()
 
-    if moveset_size < 3:
-        # there is usually a good reason for 3 moves, but less than that and we're worried about
-        # the backward accuracy
-        if pokemon.name in {
-            "Unown",
-            "Ditto",
-            "Abra",
-            "Weedle",
-            "Metapod",
-            "Caterpie",
-            "Magikarp",
-            "Pineco",
-        }:
-            pass
-        else:
-            raise TooFewMoves(p)
-    elif moveset_size > 4:
+    if moveset_size > 4:
         raise TooManyMoves(p)
 
     # sanity check on annonying spelling changes across move names

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/checks.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/checks.py
@@ -151,7 +151,7 @@ def check_noun_spelling(replay):
                 if isinstance(val, str):
                     if to_id_str(val) == val:
                         raise ForwardVerify(
-                            f"Potential to_id_str --> Proper Name mismatch: {val}"
+                            f"Potential to_id_str --> Proper Name mismatch: {val}, sometimes caused by all-lowercase logs"
                         )
 
 
@@ -187,6 +187,7 @@ def check_filled_mon(pokemon):
             "Metapod",
             "Caterpie",
             "Magikarp",
+            "Pineco",
         }:
             pass
         else:

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/checks.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/checks.py
@@ -176,6 +176,10 @@ def check_filled_mon(pokemon):
         raise BackwardException(f"Pokemon info has not been filled: {p}")
 
     moveset_size = len(pokemon.moves)
+    no_duplicates = len(pokemon.moves) == len(set(m.id for m in pokemon.moves.values()))
+    if not no_duplicates:
+        breakpoint()
+
     if moveset_size < 3:
         # there is usually a good reason for 3 moves, but less than that and we're worried about
         # the backward accuracy

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/exceptions.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/exceptions.py
@@ -207,3 +207,10 @@ class ForceSwitchMishandled(BackwardException):
 class InvalidActionIndex(BackwardException):
     def __init__(self, state, action):
         super().__init__(f"Action `{action}` is not a valid choice in state `{state}`")
+
+
+class InconsistentTeamPrediction(BackwardException):
+    def __init__(self, team1, team2):
+        super().__init__(
+            f"Team `{team1}` is not consistent with predicted team `{team2}`"
+        )

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/exceptions.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/exceptions.py
@@ -205,7 +205,5 @@ class ForceSwitchMishandled(BackwardException):
 
 
 class InvalidActionIndex(BackwardException):
-    def __init__(self, obs_text, action):
-        super().__init__(
-            f"Action `{action}` is not a valid choice in state with text description `{obs_text}`"
-        )
+    def __init__(self, state, action):
+        super().__init__(f"Action `{action}` is not a valid choice in state `{state}`")

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
@@ -676,7 +676,8 @@ def parse_row(replay: ParsedReplay, row: List[str]):
         # |-item|POKEMON|ITEM|[from]EFFECT or |-enditem|POKEMON|ITEM|[from]EFFECT
         pokemon = curr_turn.get_pokemon_from_str(data[0])
         item = data[1]
-        assert pokemon is not None
+        if pokemon is None:
+            raise RareValueError(f"Could not find pokemon from {data[0]}")
 
         # adjust active item
         if "end" in name:

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/forward.py
@@ -286,7 +286,7 @@ def parse_row(replay: ParsedReplay, row: List[str]):
         poke_list = curr_turn.get_pokemon_list_from_str(data[0])
         assert isinstance(poke_list, list)
         if None not in poke_list:
-            raise TeamTooLarge(len(poke_list) + 1)
+            raise UnusualTeamSize(len(poke_list) + 1)
         poke_name, lvl = Pokemon.identify_from_details(data[1])
         insert_at = poke_list.index(None)
         poke_list[insert_at] = Pokemon(name=poke_name, lvl=lvl, gen=replay.gen)
@@ -883,7 +883,7 @@ def parse_row(replay: ParsedReplay, row: List[str]):
             pokemon.protected = True
     
     else:
-        if data[0].startswith(">>>"):
+        if data and data[0].startswith(">>>"):
             # leaked browser console messages?
             pass
         else:
@@ -894,7 +894,7 @@ def forward_fill(replay: ParsedReplay, log: list[list[str]], verbose: bool = Fal
     for row in log:
         if row:
             if verbose:
-                print(row)
+                print(f"{replay.gameid} {row}")
             parse_row(replay, row)
 
     checks.check_noun_spelling(replay)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
@@ -28,24 +28,15 @@ class ReplayParser:
         self,
         replay_output_dir: Optional[str] = None,
         team_output_dir: Optional[str] = None,
-        train_test_split: float = 0.8,
         verbose: bool = False,
         sleep_on_handled_exception: int = 0.1,
-        reward_function: Optional[interface.RewardFunction] = None,
-        observation_space: Optional[interface.ObservationSpace] = None,
         team_predictor: Optional[TeamPredictor] = None,
     ):
         self.output_dir = replay_output_dir
         self.team_output_dir = team_output_dir
         self.verbose = verbose
-        assert 0.0 <= train_test_split <= 1.0
-        self.train_test_split = train_test_split
         self.sleep_on_handled_exception = sleep_on_handled_exception
         self.error_history = {"Forward": {}, "Backward": {}}
-        self.reward_function = reward_function or interface.DefaultShapedReward()
-        self.observation_space = (
-            observation_space or interface.DefaultObservationSpace()
-        )
         self.team_predictor = team_predictor or NaiveUsagePredictor()
 
     def summarize_errors(self):
@@ -108,61 +99,48 @@ class ReplayParser:
         self, states: list[ReplayState], actions: list[Action]
     ):
         universal_states = []
-        obs_seq = {key: [] for key in self.observation_space.gym_space.keys()}
         action_idxs = []
 
         for state, action in zip(states, actions):
             universal_state = interface.UniversalState.from_ReplayState(state)
             action_idx = interface.replaystate_action_to_idx(state, action)
-            obs = self.observation_space.state_to_obs(universal_state)
-            for obs_key, obs_val in obs.items():
-                obs_seq[obs_key].append(obs_val)
             if action_idx is None:
-                raise InvalidActionIndex(obs, action)
+                raise InvalidActionIndex(state, action)
             action_idxs.append(action_idx)
             universal_states.append(universal_state)
 
-        rewards = [0.0]
-        for prev_state, state in zip(universal_states, universal_states[1:]):
-            rewards.append(self.reward_function(prev_state, state))
-
-        obs_seq = {key: np.array(val) for key, val in obs_seq.items()}
-        action_idxs = np.array(action_idxs, dtype=np.int32)
-        rewards = np.array(rewards, dtype=np.float32)
-        return obs_seq, action_idxs, rewards
+        return universal_states, action_idxs
 
     def povreplay_to_seq(self, replay: backward.POVReplay):
         states, actions = self.povreplay_to_state_action(replay)
-        obs, action_idxs, rewards = self.state_action_to_obs_action_reward(
+        universal_states, action_idxs = self.state_action_to_obs_action_reward(
             states, actions
         )
-        return obs, action_idxs, rewards
+        return universal_states, action_idxs
 
     def save_to_disk(
         self,
         replay: backward.POVReplay,
-        to_train_set: bool,
         time_played: datetime,
         player_username: str,
         opponenent_username: str,
     ):
-        obs_seq, actions, rewards = self.povreplay_to_seq(replay)
+        universal_states, action_idxs = self.povreplay_to_seq(replay)
         won = "WIN" if replay.winner else "LOSS"
         filename = f"{replay.gameid}_{replay.rating}_{player_username}_vs_{opponenent_username}_{time_played.strftime('%m-%d-%Y')}_{won}"
-        split = "train" if to_train_set else "val"
         if self.output_dir is not None:
-            path = os.path.join(self.output_dir, split)
+            path = self.output_dir
             if not os.path.exists(path):
                 os.makedirs(path)
-            with open(os.path.join(path, f"{filename}.npz"), "wb") as f:
-                np.savez_compressed(
-                    f,
-                    **obs_seq,
-                    actions=actions,
-                    rewards=rewards,
-                )
+            output_json = {
+                "states": [state.to_dict() for state in universal_states],
+                "actions": action_idxs,
+            }
+            with open(os.path.join(path, f"{filename}.json"), "w") as f:
+                json.dump(output_json, f)
+
         if self.team_output_dir is not None:
-            path = os.path.join(self.team_output_dir, split)
+            path = self.team_output_dir
             if not os.path.exists(path):
                 os.makedirs(path)
             with open(os.path.join(path, f"{filename}.{replay.format}_team"), "w") as f:
@@ -190,6 +168,7 @@ class ReplayParser:
 
     def parse_replay(self, path: str):
         # read replay data from disk
+        print(f"Loading {path}")
         with open(path, "r") as f:
             try:
                 data = json.load(f)
@@ -215,19 +194,15 @@ class ReplayParser:
             replay_from_p1, replay_from_p2 = backward.backward_fill(
                 replay, team_predictor=self.team_predictor
             )
-
-            # save as IL/RL experience
-            to_train_set = random.random() < self.train_test_split
+            # save
             self.save_to_disk(
                 replay_from_p1,
-                to_train_set,
                 time_played=time_played,
                 player_username=p1_username,
                 opponenent_username=p2_username,
             )
             self.save_to_disk(
                 replay_from_p2,
-                to_train_set,
                 time_played=time_played,
                 player_username=p2_username,
                 opponenent_username=p1_username,

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
@@ -168,7 +168,6 @@ class ReplayParser:
 
     def parse_replay(self, path: str):
         # read replay data from disk
-        print(f"Loading {path}")
         with open(path, "r") as f:
             try:
                 data = json.load(f)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
@@ -165,6 +165,8 @@ class ReplayParser:
             pool.imap_unordered(self.parse_replay, file_paths), total=len(file_paths)
         ):
             pass
+        pool.close()
+        pool.join()
 
     def parse_replay(self, path: str):
         # read replay data from disk
@@ -191,7 +193,8 @@ class ReplayParser:
 
             # backward fill
             replay_from_p1, replay_from_p2 = backward.backward_fill(
-                replay, team_predictor=self.team_predictor
+                replay,
+                team_predictor=self.team_predictor,
             )
             # save
             self.save_to_disk(

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
@@ -75,7 +75,6 @@ class Move(PEMove):
             self.charge_move = bool(self.entry["flags"].get("charge"))
             self.name = self.entry["name"]
         except:
-            breakpoint()
             raise MovedexMissingEntry(name, self.lookup_name)
         self.gen_ = gen
         self.pp = self.current_pp  # split from poke-env PP counter

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
@@ -31,6 +31,7 @@ class Nothing(Enum):
 
 
 def _one_hidden_power(move_name: str) -> str:
+    # used to map all hidden power moves to the same name
     if move_name.startswith("Hidden Power"):
         return "Hidden Power"
     elif move_name.startswith("hiddenpower"):
@@ -85,8 +86,6 @@ class Move(PEMove):
             self.charge_move = bool(self.entry["flags"].get("charge"))
             self.name = self.entry["name"]
         except:
-            if "<nomove>" in name:
-                breakpoint()
             raise MovedexMissingEntry(name, self.lookup_name)
         self.gen_ = gen
         self.pp = self.current_pp  # split from poke-env PP counter

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
@@ -75,6 +75,8 @@ class Move(PEMove):
             self.charge_move = bool(self.entry["flags"].get("charge"))
             self.name = self.entry["name"]
         except:
+            if "<nomove>" in name:
+                breakpoint()
             raise MovedexMissingEntry(name, self.lookup_name)
         self.gen_ = gen
         self.pp = self.current_pp  # split from poke-env PP counter

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
@@ -390,7 +390,13 @@ class Pokemon:
             ability = None
         self.had_ability = ability
         pokemon_set_moves = set(
-            move for move in pokemon_set.moves if move != pokemon_set.MISSING_MOVE
+            move
+            for move in pokemon_set.moves
+            if (
+                move != pokemon_set.MISSING_MOVE
+                and move != "Struggle"
+                and move != pokemon_set.NO_MOVE
+            )
         )
         moves_to_add = pokemon_set_moves - set(self.had_moves.keys())
         while len(self.had_moves.keys()) < 4 and moves_to_add:

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
@@ -30,6 +30,15 @@ class Nothing(Enum):
     NO_STATUS = auto()
 
 
+def _one_hidden_power(move_name: str) -> str:
+    if move_name.startswith("Hidden Power"):
+        return "Hidden Power"
+    elif move_name.startswith("hiddenpower"):
+        return "hiddenpower"
+    else:
+        return move_name
+
+
 @dataclass
 class Boosts:
     atk_: int = 0
@@ -69,6 +78,7 @@ class Move(PEMove):
     def __init__(self, name: str, gen: int):
         # in an attempt to handle `choice` messages that give names in a case/space insensitive format,
         # we'll go from the name parsed from the replay --> poke_env id --> poke_env's official move name
+        name = _one_hidden_power(name)
         self.lookup_name = to_id_str(name)
         try:
             super().__init__(move_id=self.lookup_name, gen=gen)
@@ -390,7 +400,7 @@ class Pokemon:
             ability = None
         self.had_ability = ability
         pokemon_set_moves = set(
-            move
+            _one_hidden_power(move)
             for move in pokemon_set.moves
             if (
                 move != pokemon_set.MISSING_MOVE
@@ -400,7 +410,8 @@ class Pokemon:
         )
         moves_to_add = pokemon_set_moves - set(self.had_moves.keys())
         while len(self.had_moves.keys()) < 4 and moves_to_add:
-            new_move = Move(name=moves_to_add.pop(), gen=self.gen)
+            choice = moves_to_add.pop()
+            new_move = Move(name=choice, gen=self.gen)
             self.had_moves[new_move.name] = new_move
         if self.max_hp is None:
             assert self.current_hp is None

--- a/metamon/data/team_builder/team_builder.py
+++ b/metamon/data/team_builder/team_builder.py
@@ -77,21 +77,20 @@ class TeamBuilder:
     def generate_new_team(self, pokemon=None):
         self.current_team = []
 
-        def _try_add(pokemon):
-            try:
-                self.current_team.append(self.generate_moveset(pokemon))
-                return
-            except KeyError:
-                raise PokemonStatsLookupError(pokemon, self.format)
-
         # is pokemon is a list
         if type(pokemon) == list and len(pokemon) > 0:
             for p in pokemon:
-                _try_add(p)
+                try:
+                    self.current_team.append(self.generate_moveset(p))
+                except Exception as e:
+                    raise PokemonStatsLookupError(p, self.format)
             if len(self.current_team) > 0:
                 pokemon = self.current_team[-1]["name"]
         elif type(pokemon) == str:
-            _try_add(pokemon)
+            try:
+                self.current_team.append(self.generate_moveset(pokemon))
+            except Exception as e:
+                raise PokemonStatsLookupError(pokemon, self.format)
         if len(self.current_team) == 0:
             # select first pokemon purely random, top cut to 100
             pokemon = self.get_random_pm()

--- a/metamon/data/team_prediction/dataset.py
+++ b/metamon/data/team_prediction/dataset.py
@@ -2,7 +2,7 @@ import os
 import random
 import re
 import pathlib
-from typing import List, Tuple, Optional, Union, Iterable, Literal
+from typing import List, Tuple, Optional, Union, Iterable, Literal, Dict, Set
 
 import torch
 from torch.utils.data import Dataset
@@ -11,6 +11,31 @@ from metamon.data.team_prediction.team import TeamSet
 from metamon.data.team_prediction.vocabulary import Vocabulary
 from metamon.data import DATA_PATH
 from poke_env.data import to_id_str
+from metamon.data.team_prediction.team import PokemonSet
+
+
+class TeamDataset(Dataset):
+    def __init__(self, filenames, team_path, format):
+        self.filenames = filenames
+        self.team_path = team_path
+        self.format = format
+
+    def __len__(self):
+        return len(self.filenames)
+
+    def __getitem__(
+        self, idx
+    ) -> Tuple[TeamSet, Dict[str, PokemonSet], Set[str]] | None:
+        team_file = self.filenames[idx]
+        team_path_full = os.path.join(self.team_path, team_file)
+        try:
+            team = TeamSet.from_showdown_file(team_path_full, self.format)
+        except Exception as e:
+            print(f"Error loading team file {team_path_full}: {e}")
+            return None
+        pokemon_sets = {p.name: p for p in team.pokemon}
+        team_roster = set(p.name for p in team.pokemon)
+        return (team, pokemon_sets, team_roster)
 
 
 class TeamPredictionDataset(Dataset):

--- a/metamon/data/team_prediction/dataset.py
+++ b/metamon/data/team_prediction/dataset.py
@@ -28,8 +28,8 @@ class TeamPredictionDataset(Dataset):
             data_dir: Directory or iterable of directories containing .team files (will be searched recursively)
             split: Whether this is the training or validation split
             validation_ratio: Fraction of data to use for validation
-            mask_pokemon_prob: Probability of masking an entire Pokemon
-            mask_attrs_prob: Probability of masking individual attributes
+            mask_pokemon_prob_range: Range of probabilities to use for masking an entire Pokemon
+            mask_attrs_prob_range: Range of probabilities to use for masking an indivudal attribute
             seed: Random seed for reproducibility
         """
         (

--- a/metamon/data/team_prediction/generate_replay_stats.py
+++ b/metamon/data/team_prediction/generate_replay_stats.py
@@ -1,0 +1,194 @@
+"""
+A questionably efficient script that loads a set of team files and finds all unique Pokémon movesets and team rosters (6 Pokemon names)
+implied by those files. It then calculates all the possible fully revealed versions of those movesets and rosters, and counts the number
+of team files that *may have* used them.
+"""
+
+import os
+import random
+from collections import defaultdict
+from typing import Set
+
+import tqdm
+from torch.utils.data import DataLoader
+
+from metamon.data.team_prediction.dataset import TeamDataset
+from metamon.data.team_prediction.team import TeamSet, PokemonSet, Roster
+
+
+def load_replay_teams(
+    revealed_team_dir: str, format: str, max_teams: int, num_workers: int = 10
+):
+    teams = []
+    pokemon_sets = defaultdict(list)
+    team_rosters = []
+
+    dataset = TeamDataset(revealed_team_dir, format, max_teams=max_teams)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=16,
+        num_workers=num_workers,
+        prefetch_factor=2 if num_workers > 0 else None,
+        collate_fn=lambda x: x,
+    )
+
+    for batch in tqdm.tqdm(dataloader, desc="Loading Team Files", colour="blue"):
+        for result in batch:
+            if result is None:
+                continue
+            team, pokemon_dict, team_roster = result
+            teams.append(team)
+            for name, pokemon in pokemon_dict.items():
+                pokemon_sets[name].append(pokemon)
+            team_rosters.append(team_roster)
+
+    if not teams:
+        raise ValueError(f"No valid team files found in {revealed_team_dir}")
+
+    print(f"Loaded {len(teams)} teams with {len(pokemon_sets)} unique Pokémon")
+    return teams, pokemon_sets, team_rosters
+
+
+def _find_consistency_leaves(sets: list[PokemonSet | TeamSet | Set]):
+    unique = list(set(sets))
+    n = len(unique)
+    lengths = [len(s) for s in unique]
+    is_leaf = [True] * n
+
+    for i in tqdm.trange(n, desc="Finding consistency leaves", colour="green"):
+        if not is_leaf[i]:
+            continue
+        for j in range(n):
+            if i == j:
+                continue
+            # If i is consistent with j, then i is not a leaf
+            # use lengths as easy check to skip comparisons
+            if lengths[i] < lengths[j]:
+                if unique[i] < unique[j]:
+                    is_leaf[i] = False
+                    break
+
+    return [unique[i] for i in range(n) if is_leaf[i]]
+
+
+def find_pokemon_consistency_weights(sets: list[PokemonSet | TeamSet | Set]):
+    leaves = _find_consistency_leaves(sets)
+    weights = [0 for _ in leaves]
+    for s in tqdm.tqdm(sets, desc="Calculating consistency weights", colour="red"):
+        for idx, l in enumerate(leaves):
+            if s <= l:
+                weights[idx] += 1
+    return list(zip(leaves, weights))
+
+
+def _process_roster_batch(args):
+    batch_sets, leaves = args
+    result = [0] * len(leaves)
+
+    for s in batch_sets:
+        for idx, leaf in enumerate(leaves):
+            if s <= leaf:
+                result[idx] += 1
+
+    return result
+
+
+def find_team_consistency_weights(sets: list[Roster], num_workers: int = 10):
+    leaves = _find_consistency_leaves(sets)
+    print(f"Found {len(leaves)} consistency leaves")
+
+    batch_size = max(100, len(sets) // (num_workers * 2))
+    batches = [sets[i : i + batch_size] for i in range(0, len(sets), batch_size)]
+    print(f"Processing {len(batches)} batches in parallel")
+
+    from multiprocessing import Pool
+
+    with Pool(processes=num_workers) as pool:
+        all_results = list(
+            tqdm.tqdm(
+                pool.imap(
+                    _process_roster_batch, [(batch, leaves) for batch in batches]
+                ),
+                total=len(batches),
+                desc="Calculating consistency weights",
+                colour="red",
+            )
+        )
+
+    # sum up the weights from all batches
+    final_weights = [0] * len(leaves)
+    for batch_result in all_results:
+        for i, count in enumerate(batch_result):
+            final_weights[i] += count
+
+    return list(zip(leaves, final_weights))
+
+
+if __name__ == "__main__":
+    import argparse
+    import os
+    from multiprocessing import Pool
+    from collections import defaultdict
+    import json
+
+    parser = argparse.ArgumentParser(description="Generate replay stats")
+    parser.add_argument(
+        "--revealed_team_dir",
+        type=str,
+        default=None,
+        help="Directory containing revealed team files. Defaults to METAMON_TEAMFILE_PATH env var",
+    )
+    parser.add_argument(
+        "--format", type=str, default="gen9ou", help="Format to analyze"
+    )
+    parser.add_argument(
+        "--max_teams", type=int, default=1000, help="Maximum number of teams to load"
+    )
+    parser.add_argument(
+        "--workers", type=int, default=0, help="Number of worker processes"
+    )
+    args = parser.parse_args()
+
+    revealed_team_dir = args.revealed_team_dir
+    if revealed_team_dir is None:
+        revealed_team_dir = os.environ.get("METAMON_TEAMFILE_PATH", None)
+        if revealed_team_dir is None:
+            raise ValueError("METAMON_TEAMFILE_PATH environment variable not set")
+
+    teams, pokemon_sets, team_rosters = load_replay_teams(
+        revealed_team_dir,
+        format=args.format,
+        max_teams=args.max_teams,
+        num_workers=args.workers,
+    )
+
+    def process_pokemon_sets(args):
+        pokemon_name, all_sets = args
+        weights = find_pokemon_consistency_weights(all_sets)
+        sorted_sets = sorted(weights, key=lambda x: x[1], reverse=True)
+        return pokemon_name, [
+            (set_i.to_dict(), weight_i) for set_i, weight_i in sorted_sets
+        ]
+
+    pokemon_sets_items = list(pokemon_sets.items())
+    with Pool(processes=args.workers if args.workers > 0 else None) as pool:
+        results = pool.map(process_pokemon_sets, pokemon_sets_items)
+
+    processed_sets = dict(results)
+    output_dir = os.path.join(os.path.dirname(__file__), "consistent_pokemon_sets")
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, f"{args.format}_pokemon.json"), "w") as f:
+        json.dump(processed_sets, f, indent=2)
+
+    weights = find_team_consistency_weights(team_rosters, num_workers=args.workers)
+    results = {
+        "rosters": [
+            {
+                "team": roster.to_dict(),
+                "weight": weight,
+            }
+            for roster, weight in sorted(weights, key=lambda x: x[1], reverse=True)
+        ],
+    }
+    with open(os.path.join(output_dir, f"{args.format}_team_rosters.json"), "w") as f:
+        json.dump(results, f, indent=2)

--- a/metamon/data/team_prediction/generate_replay_stats.py
+++ b/metamon/data/team_prediction/generate_replay_stats.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
         results = pool.map(process_pokemon_sets, pokemon_sets_items)
 
     processed_sets = dict(results)
-    output_dir = os.path.join(os.path.dirname(__file__), "consistent_pokemon_sets")
+    output_dir = os.path.join(os.path.dirname(__file__), "replay_stats")
     os.makedirs(output_dir, exist_ok=True)
     with open(os.path.join(output_dir, f"{args.format}_pokemon.json"), "w") as f:
         json.dump(processed_sets, f, indent=2)

--- a/metamon/data/team_prediction/predictor.py
+++ b/metamon/data/team_prediction/predictor.py
@@ -1,34 +1,27 @@
 import copy
 import os
 import random
+import json
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from collections import deque, defaultdict
-import tqdm
-from torch.utils.data import DataLoader
+from collections import deque
+from typing import Set, List, Tuple
 
 from metamon.data.team_builder.team_builder import TeamBuilder, PokemonStatsLookupError
 from metamon.data.team_builder.stat_reader import PreloadedSmogonStat
-from metamon.data.team_prediction.team import TeamSet, PokemonSet
-from metamon.data.team_prediction.dataset import TeamDataset
+from metamon.data.team_prediction.team import TeamSet, PokemonSet, Roster
 
 
 class TeamPredictor(ABC):
     def __init__(self):
         pass
 
-    @property
-    def num_processes(self):
-        if not hasattr(self, "_num_processes"):
-            self._num_processes = 1
-        return self._num_processes
-
-    @num_processes.setter
-    def num_processes(self, value: int):
-        self._num_processes = value
+    def predict(self, team: TeamSet) -> TeamSet:
+        copy_team = copy.deepcopy(team)
+        return self.fill_team(copy_team)
 
     @abstractmethod
-    def predict(self, team: TeamSet) -> TeamSet:
+    def fill_team(self, team: TeamSet):
         raise NotImplementedError
 
 
@@ -38,7 +31,7 @@ def get_legacy_teambuilder(format: str):
 
 
 class NaiveUsagePredictor(TeamPredictor):
-    def predict(self, team: TeamSet):
+    def fill_team(self, team: TeamSet):
         team_builder = get_legacy_teambuilder(team.format)
         gen = int(team.format.split("gen")[1][0])
         pokemon = [team.lead] + team.reserve
@@ -105,135 +98,100 @@ class NaiveUsagePredictor(TeamPredictor):
         return final_team
 
 
-@lru_cache(maxsize=1)
-def load_replay_teams(format: str, max_teams: int, num_workers: int = 0):
-    team_path = os.environ.get("METAMON_TEAMFILE_PATH", None)
-    if team_path is None:
-        print("METAMON_TEAMFILE_PATH environment variable is not set")
-        exit()
-    team_path = os.path.join(team_path, f"{format}_teams")
+@lru_cache(maxsize=4)
+def load_replay_stats_by_format(format: str):
+    with open(
+        os.path.join(
+            os.path.dirname(__file__),
+            "consistent_pokemon_sets",
+            f"{format}_pokemon.json",
+        ),
+        "r",
+    ) as f:
+        pokemon_sets = json.load(f)
+    with open(
+        os.path.join(
+            os.path.dirname(__file__),
+            "consistent_pokemon_sets",
+            f"{format}_team_rosters.json",
+        ),
+        "r",
+    ) as f:
+        team_rosters = json.load(f)["rosters"]
 
-    # Initialize containers
-    teams = []
-    pokemon_sets = defaultdict(list)
-    team_rosters = []
+    rosters = []
+    for rw in team_rosters:
+        r = Roster.from_dict(rw["team"])
+        w = rw["weight"]
+        rosters.append((r, w))
 
-    # Get list of team files and shuffle
-    filenames = [f for f in os.listdir(team_path) if f.endswith("team")]
-    random.shuffle(filenames)
-    filenames = filenames[:max_teams]
+    sets = {}
+    for name, all_sets in pokemon_sets.items():
+        sets[name] = [
+            (PokemonSet.from_dict(p | {"name": name}), w) for p, w in all_sets
+        ]
 
-    print(f"Loading up to {len(filenames)} team files")
-
-    dataset = TeamDataset(filenames, team_path, format)
-    dataloader = DataLoader(
-        dataset,
-        batch_size=16,
-        num_workers=num_workers,
-        prefetch_factor=2 if num_workers > 0 else None,
-        collate_fn=lambda x: x,
-    )
-
-    # Process in parallel with progress bar
-    for batch in tqdm.tqdm(dataloader, desc="Loading Team Files", colour="blue"):
-        for result in batch:
-            if result is None:
-                continue
-            team, pokemon_dict, team_roster = result
-            teams.append(team)
-            for name, pokemon in pokemon_dict.items():
-                pokemon_sets[name].append(pokemon)
-            team_rosters.append(team_roster - {PokemonSet.MISSING_NAME})
-
-    if not teams:
-        raise ValueError(f"No valid team files found in {team_path}")
-
-    print(f"Loaded {len(teams)} teams with {len(pokemon_sets)} unique Pokémon")
-    return teams, pokemon_sets, team_rosters
+    return sets, rosters
 
 
 class ReplayPredictor(NaiveUsagePredictor):
-    def __init__(self, max_teams: int = 100_000):
+    def __init__(self, max_teams: int = 10_000):
         self.stat_format = None
         self.max_teams = max_teams
 
     def _load_data(self, format: str):
         self.smogon_stat = PreloadedSmogonStat(format, verbose=False, inclusive=True)
-        workers = 0 if self.num_processes > 1 else 8
-        self.teams, self.pokemon_sets, self.team_rosters = load_replay_teams(
-            format, self.max_teams, workers
-        )
-        self.stat_format = format
+        self.pokemon_sets, self.team_rosters = load_replay_stats_by_format(format)
 
-    def _fill_pokemon_by_consistency(self, pokemon: PokemonSet):
-        candidates = self.pokemon_sets[pokemon.name]
-        consistent = [
-            p for p in candidates if (pokemon.is_consistent_with(p) and pokemon != p)
-        ]
-        while len(consistent) > 1:
-            pokemon = consistent.pop(random.randint(0, len(consistent) - 1))
-            consistent = [
-                p
-                for p in consistent
-                if (pokemon.is_consistent_with(p) and pokemon != p)
-            ]
+    def sample_roster_from_candidates(
+        self, current_roster: Roster, candidates: List[Tuple[Roster, float]]
+    ):
+        weights = [w for _, w in candidates]
+        weights = [w / sum(weights) for w in weights]
+        roster = random.choices(candidates, weights=weights, k=1)[0][0]
+        return roster
+
+    def sample_pokemon_from_candidates(
+        self, current_pokemon: PokemonSet, candidates: List[PokemonSet]
+    ):
+        weights = [w for _, w in candidates]
+        weights = [w / sum(weights) for w in weights]
+        pokemon = random.choices(candidates, weights=weights, k=1)[0][0]
         return pokemon
 
-    def _fill_team_by_consistency(self, team: TeamSet):
-        consistent = [t for t in self.teams if team.is_consistent_with(t)]
-        if consistent:
-            team = consistent.pop(random.randint(0, len(consistent) - 1))
-            while len(consistent) > 1:
-                team = consistent.pop(random.randint(0, len(consistent) - 1))
-                consistent = [t for t in consistent if team.is_consistent_with(t)]
-        return team
-
-    def _fill_roster_by_consistency(self, team: TeamSet):
-        current_team_roster = set(
-            p.name for p in team.pokemon if p.name != PokemonSet.MISSING_NAME
-        )
-        candidates = [t for t in self.team_rosters if current_team_roster < t]
-        if candidates:
-            while candidates:
-                expanded_roster = candidates.pop(random.randint(0, len(candidates) - 1))
-                candidates = [t for t in candidates if expanded_roster < t]
-            new_pokemon = expanded_roster - current_team_roster
-            if not len(new_pokemon) == sum(
-                p.name == PokemonSet.MISSING_NAME for p in team.pokemon
-            ):
-                breakpoint()
-            for p in team.pokemon:
-                if p.name == PokemonSet.MISSING_NAME:
-                    p.name = new_pokemon.pop()
-        return team
-
-    def predict(self, team: TeamSet) -> TeamSet:
+    def fill_team(self, team: TeamSet) -> TeamSet:
         if self.stat_format != team.format:
             self._load_data(team.format)
-
         og_team = copy.deepcopy(team)
-        # step 1: expand the team as far as possible based on other replays that are consistent with the current team
-        team = self._fill_team_by_consistency(team)
 
-        # step 2: fill the names of missing Pokemon based on other replays
-        if any(p.name == PokemonSet.MISSING_NAME for p in team.pokemon):
-            team = self._fill_roster_by_consistency(team)
+        lead_name = team.lead.name
+        reserve_names = [p.name for p in team.reserve]
+        roster = Roster(lead=lead_name, reserve=reserve_names)
 
-        # step 3: fill each individual Pokemon with a self-consistent set
-        filled_team = []
-        for p in team.pokemon:
-            if p.name != PokemonSet.MISSING_NAME:
-                filled_team.append(self._fill_pokemon_by_consistency(p))
-            else:
-                filled_team.append(p)
+        candidates = [
+            (r, w) for r, w in self.team_rosters if roster.is_consistent_with(r)
+        ]
+        if candidates:
+            roster = self.sample_roster_from_candidates(roster, candidates)
+            assert roster.lead == lead_name
+            candidates = [p for p in roster.reserve if p not in reserve_names]
 
-        most_complete_team = TeamSet(
-            lead=filled_team[0], reserve=filled_team[1:], format=team.format
-        )
-        if not og_team.is_consistent_with(most_complete_team):
-            breakpoint()
-        # step 4: fall back to old method for any remaining info
-        return super().predict(most_complete_team)
+        for pokemon in team.pokemon:
+            if pokemon.name == PokemonSet.MISSING_NAME and candidates:
+                pokemon.name = candidates.pop()
+
+        for pokemon in team.pokemon:
+            candidates = [
+                (p, w)
+                for p, w in self.pokemon_sets[pokemon.name]
+                if pokemon.is_consistent_with(p)
+            ]
+            if candidates:
+                new_pokemon = self.sample_pokemon_from_candidates(pokemon, candidates)
+                pokemon.fill_from_PokemonSet(new_pokemon)
+
+        # fall back to old method for any remaining info
+        return super().fill_team(team)
 
 
 if __name__ == "__main__":
@@ -258,15 +216,11 @@ if __name__ == "__main__":
     print(f"Using team file: {team_file}")
 
     naive_predictor = NaiveUsagePredictor()
-    og_team = TeamSet.from_showdown_file(team_file, args.format)
+    og_team = copy.deepcopy(TeamSet.from_showdown_file(team_file, args.format))
     naive_team = naive_predictor.predict(og_team)
     consistent = og_team.is_consistent_with(naive_team)
     print(f"Consistent: {consistent}")
-    edited_team = copy.deepcopy(naive_team)
-    edited_team.lead.moves[0] = "Tackle"
-    consistent = og_team.is_consistent_with(edited_team)
-    print(f"Consistent: {consistent}")
-    improved_predictor = ImprovedUsagePredictor()
+    improved_predictor = ReplayPredictor()
     improved_team = improved_predictor.predict(og_team)
     consistent = og_team.is_consistent_with(improved_team)
     print(f"Consistent: {consistent}")

--- a/metamon/data/team_prediction/predictor.py
+++ b/metamon/data/team_prediction/predictor.py
@@ -1,9 +1,13 @@
 import copy
+import os
+import random
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from collections import deque
+from collections import deque, defaultdict
+import tqdm
 
 from metamon.data.team_builder.team_builder import TeamBuilder, PokemonStatsLookupError
+from metamon.data.team_builder.stat_reader import PreloadedSmogonStat
 from metamon.data.team_prediction.team import TeamSet, PokemonSet
 
 
@@ -89,20 +93,107 @@ class NaiveUsagePredictor(TeamPredictor):
         return final_team
 
 
+class ImprovedUsagePredictor(NaiveUsagePredictor):
+    def __init__(self, max_teams: int = 10000):
+        self.stat_format = None
+        self.max_teams = max_teams
+
+    def set_format(self, format: str):
+        if format != self.stat_format:
+            print(f"Loading new format: {format}")
+            self.smogon_stat = PreloadedSmogonStat(
+                format, verbose=False, inclusive=True
+            )
+            self.stat_format = format
+            self.teams = self.load_teams(format)
+
+    def load_teams(self, format: str):
+        team_path = os.environ.get("METAMON_TEAMFILE_PATH", None)
+        if team_path is None:
+            raise ValueError("METAMON_TEAMFILE_PATH environment variable is not set")
+        team_path = os.path.join(team_path, f"{format}_teams")
+        self.teams = []
+        self.pokemon_sets = defaultdict(list)
+        filenames = os.listdir(team_path)
+        random.shuffle(filenames)
+        for team_file in tqdm.tqdm(
+            filenames[: self.max_teams],
+            colour="blue",
+            desc="Loading Team Files for Team Prediction",
+        ):
+            if team_file.endswith("team"):
+                team_path_full = os.path.join(team_path, team_file)
+                try:
+                    team = TeamSet.from_showdown_file(team_path_full, format)
+                    self.teams.append(team)
+                    for p in team.pokemon:
+                        self.pokemon_sets[p.name].append(p)
+                except Exception as e:
+                    print(f"Failed to load team from {team_file}: {e}")
+        if not self.teams:
+            raise ValueError(f"No valid team files found in {team_path}")
+        return self.teams
+
+    def _fill_from_consistent(self, pokemon: PokemonSet):
+        candidates = self.pokemon_sets[pokemon.name]
+        consistent = [
+            p for p in candidates if (pokemon.is_consistent_with(p) and pokemon != p)
+        ]
+        while len(consistent) > 1:
+            pokemon = consistent.pop(random.randint(0, len(consistent) - 1))
+            consistent = [
+                p
+                for p in consistent
+                if (pokemon.is_consistent_with(p) and pokemon != p)
+            ]
+        return pokemon
+
+    def predict(self, team: TeamSet) -> TeamSet:
+        self.set_format(team.format)
+        consistent = [t for t in self.teams if team.is_consistent_with(t)]
+        if consistent:
+            team = consistent.pop(random.randint(0, len(consistent) - 1))
+            while len(consistent) > 1:
+                team = consistent.pop(random.randint(0, len(consistent) - 1))
+                consistent = [t for t in consistent if team.is_consistent_with(t)]
+
+        filled_team = []
+        for p in team.pokemon:
+            if p.name != PokemonSet.MISSING_NAME:
+                filled_team.append(self._fill_from_consistent(p))
+            else:
+                filled_team.append(p)
+
+        most_complete_team = TeamSet(
+            lead=filled_team[0], reserve=filled_team[1:], format=team.format
+        )
+        print(most_complete_team.to_str())
+        return super().predict(most_complete_team)
+
+
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
         description="Predict team from partial information"
     )
-    parser.add_argument("team_file", type=str, help="Path to team file")
     parser.add_argument(
         "format", type=str, help="Showdown battle format (e.g., gen1ou)"
     )
     args = parser.parse_args()
 
+    team_files = os.listdir(
+        os.path.join(os.environ["METAMON_TEAMFILE_PATH"], f"{args.format}_teams")
+    )
+    team_file = os.path.join(
+        os.environ["METAMON_TEAMFILE_PATH"],
+        f"{args.format}_teams",
+        random.choice(team_files),
+    )
+    print(f"Using team file: {team_file}")
+
     naive_predictor = NaiveUsagePredictor()
-    og_team = TeamSet.from_showdown_file(args.team_file, args.format)
+    og_team = TeamSet.from_showdown_file(team_file, args.format)
     naive_team = naive_predictor.predict(og_team)
     consistent = og_team.is_consistent_with(naive_team)
     print(f"Consistent: {consistent}")
@@ -110,6 +201,25 @@ if __name__ == "__main__":
     edited_team.lead.moves[0] = "Tackle"
     consistent = og_team.is_consistent_with(edited_team)
     print(f"Consistent: {consistent}")
-    breakpoint()
-    print(og_team.to_str())
-    print(naive_team.to_str())
+    improved_predictor = ImprovedUsagePredictor()
+    improved_team = improved_predictor.predict(og_team)
+    consistent = og_team.is_consistent_with(improved_team)
+    print(f"Consistent: {consistent}")
+    # Print teams side by side
+    og_lines = og_team.to_str().split("\n")
+    naive_lines = naive_team.to_str().split("\n")
+    improved_lines = improved_team.to_str().split("\n")
+
+    # Pad lines to equal length
+    max_len = max(len(og_lines), len(naive_lines), len(improved_lines))
+    og_lines += [""] * (max_len - len(og_lines))
+    naive_lines += [""] * (max_len - len(naive_lines))
+    improved_lines += [""] * (max_len - len(improved_lines))
+
+    # Print header
+    print(f"{'Original Team':<40}{'Naive Prediction':<40}{'Improved Prediction':<40}")
+    print("-" * 120)
+
+    # Print lines side by side
+    for og, naive, improved in zip(og_lines, naive_lines, improved_lines):
+        print(f"{og:<40}{naive:<40}{improved:<40}")

--- a/metamon/data/team_prediction/predictor.py
+++ b/metamon/data/team_prediction/predictor.py
@@ -83,4 +83,33 @@ class NaiveUsagePredictor(TeamPredictor):
                 filled_p = copy.deepcopy(p)
                 filled_p.fill_from_PokemonSet(new_p)
                 merged_team.append(filled_p)
-        return TeamSet(lead=merged_team[0], reserve=merged_team[1:], format=team.format)
+        final_team = TeamSet(
+            lead=merged_team[0], reserve=merged_team[1:], format=team.format
+        )
+        return final_team
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Predict team from partial information"
+    )
+    parser.add_argument("team_file", type=str, help="Path to team file")
+    parser.add_argument(
+        "format", type=str, help="Showdown battle format (e.g., gen1ou)"
+    )
+    args = parser.parse_args()
+
+    naive_predictor = NaiveUsagePredictor()
+    og_team = TeamSet.from_showdown_file(args.team_file, args.format)
+    naive_team = naive_predictor.predict(og_team)
+    consistent = og_team.is_consistent_with(naive_team)
+    print(f"Consistent: {consistent}")
+    edited_team = copy.deepcopy(naive_team)
+    edited_team.lead.moves[0] = "Tackle"
+    consistent = og_team.is_consistent_with(edited_team)
+    print(f"Consistent: {consistent}")
+    breakpoint()
+    print(og_team.to_str())
+    print(naive_team.to_str())

--- a/metamon/data/team_prediction/team.py
+++ b/metamon/data/team_prediction/team.py
@@ -297,6 +297,7 @@ class PokemonSet:
                 if move_raw.startswith("Hidden Power"):
                     move_raw = "Hidden Power"
                 moves[moves.index(cls.MISSING_MOVE)] = move_raw
+
         return cls(
             name=name,
             gen=gen,

--- a/metamon/data/team_prediction/team.py
+++ b/metamon/data/team_prediction/team.py
@@ -17,6 +17,7 @@ from metamon.data.team_builder.stat_reader import PreloadedSmogonStat
 
 @lru_cache
 def get_preloaded_stat(gen: int):
+    # we grab the biggest dataset we can by using ubers "inclusive" (ubers including lower tiers)
     return PreloadedSmogonStat(f"gen{gen}ubers", inclusive=True, verbose=False)
 
 
@@ -27,10 +28,7 @@ def moveset_size(pokemon_name: str, gen: int) -> int:
             set(stat.get_from_inclusive(pokemon_name)["moves"].keys()) - {"Nothing"}
         )
     except KeyError:
-        print(f"KeyError for {pokemon_name} in gen {gen}")
         return 4
-    if moves < 4:
-        breakpoint()
     moveset = min(moves, 4)
     return moveset
 
@@ -60,8 +58,6 @@ class PokemonSet:
     MISSING_NATURE = "$missing_nature$"
 
     def __post_init__(self):
-        if self.name != self.MISSING_NAME:
-            assert len(self.moves) == moveset_size(self.name, self.gen)
         assert len(self.evs) == 6
         assert len(self.ivs) == 6
         assert self.nature is not None

--- a/metamon/data/team_prediction/team.py
+++ b/metamon/data/team_prediction/team.py
@@ -71,6 +71,22 @@ class PokemonSet:
         ]
         self.missing_regex = re.compile("|".join(map(re.escape, self.missing_strings)))
 
+    def __eq__(self, other):
+        if not isinstance(other, PokemonSet):
+            return False
+        possible = (
+            self.name == other.name
+            and self.gen == other.gen
+            and self.ability == other.ability
+            and self.item == other.item
+            and self.nature == other.nature
+            and self.evs == other.evs
+            and self.ivs == other.ivs
+        )
+        if possible and set(self.moves) == set(other.moves):
+            return True
+        return False
+
     def is_consistent_with(self, other) -> bool:
         """
         Determines whether this Pokemon is "consistent" with another Pokemon,
@@ -280,10 +296,7 @@ class PokemonSet:
                 # normalize Hidden Power by dropping any specific type
                 if move_raw.startswith("Hidden Power"):
                     move_raw = "Hidden Power"
-                try:
-                    moves[moves.index(cls.MISSING_MOVE)] = move_raw
-                except ValueError:
-                    breakpoint()
+                moves[moves.index(cls.MISSING_MOVE)] = move_raw
         return cls(
             name=name,
             gen=gen,

--- a/metamon/data/team_prediction/team.py
+++ b/metamon/data/team_prediction/team.py
@@ -558,6 +558,10 @@ class TeamSet:
     reserve: List[PokemonSet]
     format: str
 
+    @property
+    def known_pokemon(self) -> List[PokemonSet]:
+        return [p for p in self.pokemon if p.name != PokemonSet.MISSING_NAME]
+
     def __eq__(self, other):
         return (
             self.format == other.format

--- a/metamon/interface.py
+++ b/metamon/interface.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import Optional, List
 from abc import ABC, abstractmethod
 
@@ -481,55 +481,14 @@ class UniversalState:
             battle_lost=battle.lost if battle.lost else False,
             opponents_remaining=opponents_remaining,
         )
-
-    # fmt: on
-
-    def to_numpy(self) -> dict[str, np.ndarray]:
-        print("in universal state!!!!")
-        player_str = (
-            f"<player> {self.player_active_pokemon.get_string_features(active=True)}"
-        )
-        numerical = [
-            self.opponents_remaining / 6.0
-        ] + self.player_active_pokemon.get_numerical_features(active=True)
-
-        # consistent move order
-        move_str, move_num = "", -1
-        for move_num, move in enumerate(
-            consistent_move_order(self.player_active_pokemon.moves)
-        ):
-            move_str += f" <move> {move.get_string_features(active=True)}"
-            numerical += move.get_numerical_features(active=True)
-
-        while move_num < 3:
-            move_str += f" <move> {UniversalMove.get_pad_string(active=True)}"
-            numerical += UniversalMove.get_pad_numerical(active=True)
-            move_num += 1
-
-        # consistent switch order
-        switch_str, switch_num = "", -1
-        for switch_num, switch in enumerate(
-            consistent_pokemon_order(self.available_switches)
-        ):
-            switch_str += f" <switch> {switch.get_string_features(active=False)}"
-            numerical += switch.get_numerical_features(active=False)
-        while switch_num < 4:
-            switch_str += f" <switch> {UniversalPokemon.get_pad_string(active=False)}"
-            numerical += UniversalPokemon.get_pad_numerical(active=False)
-            switch_num += 1
-
-        force_switch = "<forcedswitch>" if self.forced_switch else "<anychoice>"
-        opponent_str = f"<opponent> {self.opponent_active_pokemon.get_string_features(active=True)}"
-        numerical += self.opponent_active_pokemon.get_numerical_features(active=True)
-        global_str = f"<conditions> {self.weather} {self.player_conditions} {self.opponent_conditions}"
-        prev_move_str = f"<player_prev> {self.player_prev_move.get_string_features(active=False)} <opp_prev> {self.opponent_prev_move.get_string_features(active=False)}"
-
-        text = np.array(
-            f"<{self.format}> {force_switch} {player_str} {move_str.strip()} {switch_str.strip()} {opponent_str} {global_str} {prev_move_str}",
-            dtype=np.str_,
-        )
-        numbers = np.array(numerical, dtype=np.float32)
-        return {"text": text, "numbers": numbers}
+    
+    def to_dict(self) -> dict:
+        return asdict(self)
+    
+    @classmethod
+    def from_dict(cls, data: dict):
+        #return cls(**data)
+        raise NotImplementedError
 
 
 def replaystate_action_to_idx(

--- a/metamon/interface.py
+++ b/metamon/interface.py
@@ -81,6 +81,12 @@ def consistent_move_order(moves):
     return sorted(moves, key=key)
 
 
+@lru_cache(9)
+def hidden_power_reference(gen: int) -> Move:
+    # we will map all hidden powers to this move
+    return Move(move_id="hiddenpower", gen=gen)
+
+
 @dataclass
 class UniversalMove:
     name: str
@@ -151,13 +157,20 @@ class UniversalMove:
         if move is None:
             return cls.blank_move()
         assert isinstance(move, Move)
+        if move.id.startswith("hiddenpower"):
+            # we map every hidden power to the typeless version
+            # because the types don't show up in replays
+            reference = hidden_power_reference(move._gen)
+        else:
+            reference = move
         return cls(
-            name=move.id,
-            category=move.category.name,
-            base_power=move.base_power,
-            move_type=move.type.name,
-            priority=move.priority,
-            accuracy=move.accuracy,
+            name=reference.id,
+            category=reference.category.name,
+            base_power=reference.base_power,
+            move_type=reference.type.name,
+            priority=reference.priority,
+            accuracy=reference.accuracy,
+            # always use `move` for pp tracking
             current_pp=move.current_pp,
             max_pp=move.max_pp,
         )

--- a/metamon/interface.py
+++ b/metamon/interface.py
@@ -89,7 +89,8 @@ class UniversalMove:
     base_power: int
     accuracy: float
     priority: int
-    pp: int
+    current_pp: int
+    max_pp: int
 
     def __post_init__(self):
         for name, should_be in self.__annotations__.items():
@@ -131,7 +132,8 @@ class UniversalMove:
             base_power=0,
             accuracy=1.0,
             priority=0,
-            pp=0,
+            current_pp=0,
+            max_pp=0,
         )
 
     @classmethod
@@ -140,7 +142,8 @@ class UniversalMove:
         # a different pp tracker
         universal_move = cls.from_Move(move)
         if move is not None:
-            universal_move.pp = move.pp
+            universal_move.current_pp = move.pp
+            universal_move.max_pp = move.maximum_pp
         return universal_move
 
     @classmethod
@@ -155,7 +158,8 @@ class UniversalMove:
             move_type=move.type.name,
             priority=move.priority,
             accuracy=move.accuracy,
-            pp=move.current_pp,
+            current_pp=move.current_pp,
+            max_pp=move.max_pp,
         )
 
 


### PR DESCRIPTION
Part of WIP #7 

- The parsed replay dataset will soon be hosted on hugginface as `interface.UniversalStates` so that we can change the observation space on the fly.
- Adds a new team prediction strategy that restricts pokemon/team completions to likely combinations that actually appear in replays.
- Sorts out a discrepancy between `Hidden Power [Type]` and `Hidden Power`. The replay parser only ever finds `Hidden Power` because types aren't shown in the log.