### PR TITLE
Save *online* trajectories in same format as parsed replays

### DIFF
--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/README.md
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/README.md
@@ -23,8 +23,8 @@ More information and discussion in Appendix D of the paper.
 Please be warned that it is poorly documented and requires significant Pokémon knowledge to debug/improve/extend. It is not really expected that this part of the codebase will be used externally. However, you can open an issue and I will get back to you. Updates are expected:
 
 ### Roadmap
-- Improved team inference logic (beyond all-time averages of Showdown usage stats)
+- Improved team inference logic (beyond all-time averages of Showdown usage stats) ✅ 
+- Support arbitrary observation spaces / reward functions ✅
 - Support for Gen1-4 random battles
-- Observation space extensions to address our main limitations (sleep/freeze clause tracking, PP counts)
 
 I've received a lot of questions about support for later generations and doubles battles. This replay parser is the main obstacle. I am interested in expanding to new battle formats, but do not expect to get to this myself in the near future. **I would absolutely welcome PRs from Showdown community members**. Feel free to open an issue or get in touch with me at `grigsby[at]cs[dot]utexas[dot]edu`.

--- a/metamon/env.py
+++ b/metamon/env.py
@@ -114,9 +114,13 @@ class PokeEnvWrapper(OpenAIGymEnv):
         opponent_account_configuration = AccountConfiguration(
             self.opponent_username, None
         )
-        self.save_trajectories_to = save_trajectories_to
-        if self.save_trajectories_to is not None:
+        if save_trajectories_to is not None:
+            self.save_trajectories_to = os.path.join(
+                save_trajectories_to, battle_format
+            )
             os.makedirs(self.save_trajectories_to, exist_ok=True)
+        else:
+            self.save_trajectories_to = None
 
         if opponent_type is not None:
             self.metamon_opponent_name = opponent_type.__name__
@@ -211,7 +215,7 @@ class PokeEnvWrapper(OpenAIGymEnv):
 
             if self.save_trajectories_to is not None:
                 # build a long filename that matches the format of the parsed replay dataset
-                result = "WIN" if info["win"] == 1 else "LOSS"
+                result = "WIN" if info["won"] == 1 else "LOSS"
                 battle_id = "".join(str(random.randint(0, 9)) for _ in range(10))
                 timestamp = datetime.now().strftime("%m-%d-%Y-%H:%M:%S")
                 filename = f"metamon-{self.metamon_battle_format}-{battle_id}_Unrated_{self.player_username}_vs_{self.metamon_opponent_name}_{timestamp}_{result}.json"


### PR DESCRIPTION
the paper converted the metamon replay dataset to amago trajectory files, then saved self-play experience as amago trajectory files directly.


the new version skips the trajectory conversion and loads RL data from replay jsons. now the environment can save online trajectories in that same format.