### PR TITLE
Replay Dataset v2

### DIFF
--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/__main__.py
@@ -49,6 +49,11 @@ if __name__ == "__main__":
         help="Number of parallel parser processes to run",
     )
     parser.add_argument(
+        "--replay_stats_dir",
+        default=None,
+        help="Directory for existing replay team statistics. If not provided, will default to the official version in the cached parsed replay dataset from hf.",
+    )
+    parser.add_argument(
         "--output_dir",
         default=None,
         help="Directory for output .npz files. `None` runs w/o saving to disk. Data will be saved to {--output_dir}/gen{gen}{format}",
@@ -93,7 +98,9 @@ if __name__ == "__main__":
         replay_output_dir=output_dir,
         team_output_dir=team_output_dir,
         verbose=args.verbose,
-        team_predictor=eval(args.team_predictor)(),
+        team_predictor=eval(args.team_predictor)(
+            replay_stats_dir=args.replay_stats_dir
+        ),
     )
     if args.processes > 1:
         random.shuffle(filenames)

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -12,6 +12,7 @@ from metamon.data.replay_dataset.parsed_replays.replay_parser.replay_state impor
     Pokemon,
     Turn,
     Winner,
+    BackwardMarkers,
     get_pokedex_and_moves,
     unknown,
 )
@@ -69,6 +70,13 @@ def fill_missing_team_info(
         else:
             raise BackwardException(f"Could not find match for {p.name}")
         p.fill_from_PokemonSet(match)
+        if (
+            p.had_item == BackwardMarkers.FORCE_UNKNOWN
+            or p.had_ability == BackwardMarkers.FORCE_UNKNOWN
+        ):
+            raise BackwardException(
+                f"Leaked BackwardMarkers.FORCE_UNKNOWN for {p.had_item} or {p.had_ability} with predicted match {match}"
+            )
 
     return poke_list, revealed_team
 

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/backward.py
@@ -41,7 +41,10 @@ def fill_missing_team_info(
     )
 
     # 2. Predict the team
-    predicted_team = team_predictor.predict(revealed_team)
+    try:
+        predicted_team = team_predictor.predict(revealed_team)
+    except Exception as e:
+        raise BackwardException(f"Error predicting team: {e}")
     if not revealed_team.is_consistent_with(predicted_team):
         raise InconsistentTeamPrediction(revealed_team, predicted_team)
 

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/parse_replays.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Optional
 
 import numpy as np
+import lz4.frame
 from metamon import interface
 from metamon.data.replay_dataset.parsed_replays.replay_parser import backward, forward
 from metamon.data.replay_dataset.parsed_replays.replay_parser.exceptions import (
@@ -130,14 +131,13 @@ class ReplayParser:
         filename = f"{replay.gameid}_{replay.rating}_{player_username}_vs_{opponenent_username}_{time_played.strftime('%m-%d-%Y')}_{won}"
         if self.output_dir is not None:
             path = self.output_dir
-            if not os.path.exists(path):
-                os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
             output_json = {
                 "states": [state.to_dict() for state in universal_states],
                 "actions": action_idxs,
             }
-            with open(os.path.join(path, f"{filename}.json"), "w") as f:
-                json.dump(output_json, f)
+            with lz4.frame.open(os.path.join(path, f"{filename}.json.lz4"), "wb") as f:
+                f.write(json.dumps(output_json).encode("utf-8"))
 
         if self.team_output_dir is not None:
             path = self.team_output_dir

--- a/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
+++ b/metamon/data/replay_dataset/parsed_replays/replay_parser/replay_state.py
@@ -80,10 +80,16 @@ class Move(PEMove):
         # in an attempt to handle `choice` messages that give names in a case/space insensitive format,
         # we'll go from the name parsed from the replay --> poke_env id --> poke_env's official move name
         name = _one_hidden_power(name)
-        self.lookup_name = to_id_str(name)
+        lookup_name = to_id_str(name)
+
+        # manual spelling changes between replays and move reference data
+        if lookup_name == "vicegrip":
+            lookup_name = "visegrip"
+        self.lookup_name = lookup_name
         try:
             super().__init__(move_id=self.lookup_name, gen=gen)
             self.charge_move = bool(self.entry["flags"].get("charge"))
+            # note we're taking the name as it would appear after poke-env data lookup
             self.name = self.entry["name"]
         except:
             raise MovedexMissingEntry(name, self.lookup_name)

--- a/metamon/data/replay_dataset/raw_replays/plot_replays_by_date.py
+++ b/metamon/data/replay_dataset/raw_replays/plot_replays_by_date.py
@@ -109,30 +109,38 @@ def plot_format_subplots(data: dict, fig: plt.Figure) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="Plot replay time series data")
-    parser.add_argument("json_path", type=str, help="Path to time series JSON file")
+    parser.add_argument(
+        "json_paths", type=str, nargs="+", help="Path(s) to time series JSON file"
+    )
+    parser.add_argument("--output", type=str, help="Output figure names")
     args = parser.parse_args()
 
     # Load data
-    data = load_time_series(args.json_path)
+    all_data = {}
+    for json_path in args.json_paths:
+        data = load_time_series(json_path)
+        for tier, tier_data in data.items():
+            if tier not in all_data:
+                all_data[tier] = []
+            all_data[tier].extend(tier_data)
 
     # Set style
     plt.style.use("seaborn-v0_8-darkgrid")
 
     # Create figure for aggregate plot
     fig1, ax1 = plt.subplots(figsize=(12, 6))
-    plot_aggregate_time_series(data, ax1)
+    plot_aggregate_time_series(all_data, ax1)
     fig1.tight_layout()
 
     # Create figure for format subplots
     fig2 = plt.figure(figsize=(15, 10))
-    plot_format_subplots(data, fig2)
+    plot_format_subplots(all_data, fig2)
     fig2.tight_layout()
 
     # Save plots
-    name = args.json_path.replace(".json", "")
-    fig1.savefig(f"{name}_aggregate.png", bbox_inches="tight", dpi=300)
-    fig2.savefig(f"{name}_by_format.png", bbox_inches="tight", dpi=300)
-    print(f"Saved plots to {name}_aggregate.png and {name}_by_format.png")
+    fig1.savefig(f"{args.output}_aggregate.png", bbox_inches="tight", dpi=300)
+    fig2.savefig(f"{args.output}_by_format.png", bbox_inches="tight", dpi=300)
+    print(f"Saved plots to {args.output}_aggregate.png and {args.output}_by_format.png")
     plt.close()
 
 

--- a/metamon/data/replay_dataset/raw_replays/replay_intake.py
+++ b/metamon/data/replay_dataset/raw_replays/replay_intake.py
@@ -428,18 +428,21 @@ def main():
         help="Only process replays matching these formats (e.g., gen1ou gen1ubers). Default: process all formats",
     )
     parser.add_argument(
-        "--target-dir",
+        "--target_dir",
         type=str,
+        required=True,
         help="Target directory to copy valid replays into an organized structure",
     )
     parser.add_argument(
         "--processes",
         type=int,
+        default=1,
         help="Number of processes to use for parallel processing. Default: number of CPU cores minus 1",
     )
     parser.add_argument(
-        "--save-time-series",
+        "--save_time_series",
         type=str,
+        required=True,
         help="Path to save monthly time series data for each format (as JSON)",
     )
     args = parser.parse_args()

--- a/metamon/data/team_prediction/predictor.py
+++ b/metamon/data/team_prediction/predictor.py
@@ -122,7 +122,7 @@ def load_replay_stats_by_format(format: str, replay_stats_dir: Optional[str] = N
     This loads large json files that are created by the `generate_replay_stats` script.
     """
     if replay_stats_dir is None:
-        replay_stats_dir = download.download_replay_stats(format)
+        replay_stats_dir = download.download_replay_stats()
     pokemon_set_path = os.path.join(
         replay_stats_dir,
         f"{format}_pokemon.json",
@@ -131,10 +131,6 @@ def load_replay_stats_by_format(format: str, replay_stats_dir: Optional[str] = N
         replay_stats_dir,
         f"{format}_team_rosters.json",
     )
-    if not os.path.exists(pokemon_set_path) or not os.path.exists(team_roster_path):
-        raise FileNotFoundError(
-            f"Stat files not found for format {format}. To use ReplayPredictor, you must first run `python -m metamon.data.team_prediction.generate_replay_stats`"
-        )
     with open(pokemon_set_path, "r") as f:
         pokemon_sets = json.load(f)
     with open(team_roster_path, "r") as f:

--- a/metamon/data/team_prediction/team.py
+++ b/metamon/data/team_prediction/team.py
@@ -10,6 +10,7 @@ import unicodedata
 from metamon.data.replay_dataset.parsed_replays.replay_parser.replay_state import (
     Pokemon,
     Nothing,
+    BackwardMarkers,
 )
 from metamon.data.legacy_team_builder.stat_reader import PreloadedSmogonStat
 
@@ -265,13 +266,19 @@ class PokemonSet:
         # maintaining the replay parser's distinction between "known to be None" and "unrevealed"
         if pokemon.gen == 1 or pokemon.had_item == Nothing.NO_ITEM:
             item = cls.NO_ITEM
-        elif pokemon.had_item is None:
+        elif (
+            pokemon.had_item is None
+            or pokemon.had_item == BackwardMarkers.FORCE_UNKNOWN
+        ):
             item = cls.MISSING_ITEM
         else:
             item = pokemon.had_item
         if pokemon.gen <= 2 or pokemon.had_ability == Nothing.NO_ABILITY:
             ability = cls.NO_ABILITY
-        elif pokemon.had_ability is None:
+        elif (
+            pokemon.had_ability is None
+            or pokemon.had_ability == BackwardMarkers.FORCE_UNKNOWN
+        ):
             ability = cls.MISSING_ABILITY
         else:
             ability = pokemon.had_ability

--- a/metamon/download.py
+++ b/metamon/download.py
@@ -65,13 +65,11 @@ def download_parsed_replays(
     """
     if METAMON_CACHE_DIR is None:
         raise ValueError("METAMON_CACHE_DIR environment variable is not set")
-
     parsed_replay_dir = os.path.join(METAMON_CACHE_DIR, "parsed-replays")
     tar_path = os.path.join(parsed_replay_dir, f"{battle_format}.tar.gz")
-    extract_path = os.path.join(parsed_replay_dir, battle_format)
-    if os.path.exists(extract_path) and not force_download:
-        return extract_path
-
+    out_path = os.path.join(parsed_replay_dir, battle_format)
+    if os.path.exists(out_path) and not force_download:
+        return out_path
     hf_hub_download(
         cache_dir=os.path.join(METAMON_CACHE_DIR, "parsed-replays"),
         repo_id="jakegrigsby/metamon-parsed-replays",
@@ -82,10 +80,14 @@ def download_parsed_replays(
     )
     with tarfile.open(tar_path) as tar:
         print(f"Extracting {tar_path}...")
+        if version > "v1":
+            extract_path = parsed_replay_dir
+        else:
+            extract_path = out_path
         tar.extractall(path=extract_path)
     os.remove(tar_path)
     _update_version_reference("parsed-replays", battle_format, version)
-    return extract_path
+    return out_path
 
 
 def download_teams(

--- a/metamon/download.py
+++ b/metamon/download.py
@@ -12,8 +12,8 @@ if METAMON_CACHE_DIR is not None:
 else:
     VERSION_REFERENCE_PATH = None
 
-LATEST_RAW_REPLAY_REVISION = "v1"
-LATEST_PARSED_REPLAY_REVISION = "v1"
+LATEST_RAW_REPLAY_REVISION = "v2"
+LATEST_PARSED_REPLAY_REVISION = "v2"
 LATEST_TEAMS_REVISION = "v1"
 
 
@@ -152,7 +152,7 @@ def download_raw_replays(version: str = LATEST_RAW_REPLAY_REVISION) -> str:
     Download the "raw" (unpprocessed) replays. We maintain a dataset of replays downloaded from Pokémon Showdown for convenience. Our versions are also stripped of player usernames and in-game chat logs.
 
     Args:
-        version: Version of the dataset to download. Corresponds to revisions on the Hugging Face Hub. Defaults to the latest version.
+        version: Version of the dataset to download. Corresponds to revisions / git tags on the Hugging Face Hub. Defaults to the latest version.
     """
     from metamon.data.replay_dataset.raw_replays.download_from_hf import process_dataset
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "wandb",
         "einops",
         "tqdm",
+        "lz4",
         "accelerate>=1.0",
         "termcolor",
         "huggingface_hub",


### PR DESCRIPTION
Updates the raw replay dataset and parsed replay dataset on huggingface to "v2", which adds (~8k) may 2025 replays, but mainly:

- fixes `BackwardMarkers.FORCE_UNKNOWN` becoming a literal item/ability name in parsed replays, when they were meant to be predicted during replay parsing.
- Keeps battles compressed so that the entire dataset takes much less disk space 