### PR TITLE
Revisit Forme / Pokemon Name Changes

### DIFF
--- a/metamon/data/replay_dataset/replay_parser/checks.py
+++ b/metamon/data/replay_dataset/replay_parser/checks.py
@@ -134,6 +134,19 @@ def check_forward_consistency(replay):
                     raise ForwardVerify(f"{pokemon_t.name} PP of {lowest_pp_move} < 0")
 
 
+def check_name_permanence(replay):
+    uid_to_had_name = {}
+    for turn in replay:
+        for pokemon in turn.all_pokemon:
+            if pokemon is None:
+                continue
+            if pokemon.unique_id in uid_to_had_name:
+                if uid_to_had_name[pokemon.unique_id] != pokemon.had_name:
+                    raise ForwardVerify(f"Found had_name change for {pokemon.name}")
+            else:
+                uid_to_had_name[pokemon.unique_id] = pokemon.had_name
+
+
 def check_noun_spelling(replay):
     for turn in replay:
         for pokemon in turn.all_pokemon:

--- a/metamon/data/replay_dataset/replay_parser/forward.py
+++ b/metamon/data/replay_dataset/replay_parser/forward.py
@@ -1141,8 +1141,10 @@ class SimProtocol:
         if pokemon.had_name is None:
             pokemon.had_name = pokemon.name
         name, lvl = Pokemon.identify_from_details(args[1])
+        # poke-env actually blocks the equivalent "species" change here, but confusingly ends
+        # up changing the name anyway on the next request message.
         pokemon.name = name
-        pokemon.lvl = lvl
+        pokemon.update_pokedex_info(name)
         found_item, found_ability, found_move, found_mon = parse_from_effect_of(args)
         if found_ability:
             pokemon.reveal_ability(found_ability)
@@ -1535,4 +1537,5 @@ def forward_fill(
     checks.check_finished(replay)
     checks.check_replay_rules(replay)
     checks.check_forward_consistency(replay)
+    checks.check_name_permanence(replay)
     return replay

--- a/metamon/data/replay_dataset/replay_parser/parse_replays.py
+++ b/metamon/data/replay_dataset/replay_parser/parse_replays.py
@@ -234,5 +234,5 @@ class ReplayParser:
             self.add_exception_to_history(e, path)
             warning_str = f"{replay.gameid}:\n\t{e}"
             for check_warning in replay.check_warnings:
-                warning_str += f"\n\t{termcolor.colored(f'Note: this replay has a {check_warning.flag.value} warning flag, which may explain the above message.', 'yellow')}"
+                warning_str += f"\n\t{termcolor.colored(f'Note: this replay has a {check_warning.value} warning flag, which may explain the above message.', 'yellow')}"
             warnings.warn(warning_str)

--- a/metamon/data/replay_dataset/replay_parser/replay_state.py
+++ b/metamon/data/replay_dataset/replay_parser/replay_state.py
@@ -218,8 +218,6 @@ class Pokemon:
         self.had_type: Optional[List[str]] = None
         self.tera_type: Optional[str] = None
         self.base_stats: Dict[str, int] = {}
-        self.update_pokedex_info(name)
-        assert self.type is not None
 
         self.active_item: Optional[str] = None
         self.had_item: Optional[str] = None
@@ -242,6 +240,7 @@ class Pokemon:
         self.last_target: Optional[Targeting] = None
         self.last_targeted_by: Optional[TargetedBy] = None
         self.tricking: Optional["Pokemon"] = None
+        self.update_pokedex_info(name)
 
     def __eq__(self, other):
         # the unique id is what ultimately matters. the showdown messages
@@ -266,11 +265,8 @@ class Pokemon:
         if len(possible_abilities) == 1:
             only_ability = possible_abilities[0]
             if only_ability == "No Ability":
-                self.active_ability = Nothing.NO_ABILITY
-            else:
-                self.active_ability = only_ability
-            if self.had_ability is None:
-                self.had_ability = self.active_ability
+                only_ability = Nothing.NO_ABILITY
+            self.reveal_ability(only_ability)
 
     def on_switch_out(self):
         # many temporary effects and changes revert on switch out

--- a/metamon/interface.py
+++ b/metamon/interface.py
@@ -194,6 +194,7 @@ class UniversalPokemon:
 
     # version-specific
     tera_type: str
+    permanent_name: str
 
     @classmethod
     def from_dict(cls, data: dict):
@@ -281,25 +282,17 @@ class UniversalPokemon:
             f"{stat}boost": getattr(pokemon.boosts, stat)
             for stat in pokemon.boosts.stat_attrs
         }
-
-        item = cls.universal_items(pokemon.active_item)
-        ability = cls.universal_abilities(pokemon.active_ability)
-        status = cls.universal_status(pokemon.status)
-        effect = cls.universal_effects(pokemon.effects)
-        types = cls.universal_types(pokemon.type)
-        name = clean_name(pokemon.name)
-        tera_type = cls.universal_types([pokemon.tera_type], force_two=False)
-
         return cls(
-            name=name,
+            name=clean_name(pokemon.name),
+            permanent_name=clean_name(pokemon.had_name),
             hp_pct=float(pokemon.current_hp) / pokemon.max_hp,
-            types=types,
-            tera_type=tera_type,
-            item=item,
-            ability=ability,
+            types=cls.universal_types(pokemon.type),
+            tera_type=cls.universal_types([pokemon.tera_type], force_two=False),
+            item=cls.universal_items(pokemon.active_item),
+            ability=cls.universal_abilities(pokemon.active_ability),
             lvl=pokemon.lvl,
-            status=status,
-            effect=effect,
+            status=cls.universal_status(pokemon.status),
+            effect=cls.universal_effects(pokemon.effects),
             moves=moves,
             **(boosts | stats),
         )
@@ -309,23 +302,17 @@ class UniversalPokemon:
         moves = [UniversalMove.from_Move(move) for move in pokemon.moves.values()]
         boosts = {f"{stat}_boost": boost for stat, boost in pokemon.boosts.items()}
         stats = {f"base_{stat}": val for stat, val in pokemon.base_stats.items()}
-        status = cls.universal_status(pokemon.status)
-        effect = cls.universal_effects(pokemon.effects)
-        item = cls.universal_items(pokemon.item)
-        ability = cls.universal_abilities(pokemon.ability)
-        types = cls.universal_types(pokemon.types)
-        tera_type = cls.universal_types([pokemon.tera_type], force_two=False)
-
         return cls(
             name=clean_name(pokemon.species),
+            permanent_name=clean_name(pokemon.base_species),
             hp_pct=float(pokemon.current_hp_fraction),
-            types=types,
-            tera_type=tera_type,
-            item=item,
-            ability=ability,
+            types=cls.universal_types(pokemon.types),
+            tera_type=cls.universal_types([pokemon.tera_type], force_two=False),
+            item=cls.universal_items(pokemon.item),
+            ability=cls.universal_abilities(pokemon.ability),
             lvl=pokemon.level,
-            status=status,
-            effect=effect,
+            status=cls.universal_status(pokemon.status),
+            effect=cls.universal_effects(pokemon.effects),
             moves=moves,
             **(boosts | stats),
         )
@@ -350,7 +337,7 @@ class UniversalPokemon:
         p._moves = {m.lookup_name: m for m in pokemon.moves.values()}
         for m in p._moves.values():
             m.set_pp(m.pp)
-        p._name = pokemon.name
+        p._name = pokemon.nickname
         p._species = pokemon.name
         p._active = is_active
         p._boosts = pokemon.boosts.to_dict()
@@ -523,6 +510,8 @@ class UniversalAction:
 
         action_idx = None
         if action is None or (action.name is None and action.is_tera):
+            # action was never revealed
+            # (or tera animation was shown but the rest of the action was never revealed)
             action_idx = -1
         elif action.is_noop:
             assert action.name == "Recharge"
@@ -686,7 +675,7 @@ class DefaultShapedReward(RewardFunction):
             last_state.player_active_pokemon,
             *last_state.available_switches,
         ]:
-            if pokemon.name == active_now.name:
+            if pokemon.permanent_name == active_now.permanent_name:
                 active_prev = pokemon
                 break
         assert active_prev is not None
@@ -696,7 +685,7 @@ class DefaultShapedReward(RewardFunction):
         )
         opp_now = state.opponent_active_pokemon
         opp_prev = last_state.opponent_active_pokemon
-        if opp_now.name == opp_prev.name:
+        if opp_now.permanent_name == opp_prev.permanent_name:
             damage_done = opp_prev.hp_pct - opp_now.hp_pct
             gave_status = float(
                 opp_now.status != "nostatus" and opp_prev.status == "nostatus"
@@ -1020,7 +1009,7 @@ class DefaultPlusObservationSpace(DefaultObservationSpace):
 
         # add a list of revealed opponents padded to length 6 while reusing
         # the existing <blank> token to avoid making a new vocabulary.
-        self.revealed_opponents.add(opponent.name)
+        self.revealed_opponents.add(opponent.permanent_name)
         revealed = [opp_name for opp_name in sorted(self.revealed_opponents)]
         while len(revealed) < 6:
             revealed.append("<blank>")

--- a/metamon/interface.py
+++ b/metamon/interface.py
@@ -338,7 +338,7 @@ class UniversalPokemon:
         for m in p._moves.values():
             m.set_pp(m.pp)
         p._name = pokemon.nickname
-        p._species = pokemon.name
+        p._species = to_id_str(pokemon.name)
         p._active = is_active
         p._boosts = pokemon.boosts.to_dict()
         p._current_hp = pokemon.current_hp


### PR DESCRIPTION
Fixes a mismatch between metamon name / had_name and poke-env species / base_species that is much more relevant in gen9 where "forme" changes are common